### PR TITLE
chore: Update cache & PNPM setup versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,14 +21,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
       - name: Cache PNPM
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Setup PNPM & Install Packages
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v4
         with:
           version: 8
           run_install: true


### PR DESCRIPTION
Updates the version of `actions/cache` and `pnpm/action-setup` to their latest major versions.