### PR TITLE
chore: Lint PR titles with conventional commit format

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,23 @@
+name: Lint PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint-pr-title:
+    name: Validate Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      statuses: write
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true


### PR DESCRIPTION
Ensures your PR titles will follow conventional commit format. Meaning your squashed commits will adhere to conventional commits too.